### PR TITLE
处理sha-1不满40位的情况

### DIFF
--- a/src/Blob.java
+++ b/src/Blob.java
@@ -1,7 +1,7 @@
 import java.io.*;
 
 public class Blob {
-    private String type; // type is always bolb
+    private String type; // type is always blob
     private String name; // hash code of the content
     FileInputStream input;
     public Blob(String filename) throws Exception {

--- a/src/SHA1CheckSum.java
+++ b/src/SHA1CheckSum.java
@@ -42,7 +42,11 @@ public class SHA1CheckSum {
     public String getSha1(){
         outFile = "";
         int n = sha1.length;
-        for(int i = 0;i<n;i++){
+        for(int i = 0;i< n;i++){
+            if((int) sha1[i] < 16){
+                outFile = outFile + "0" + Integer.toString(sha1[i]&0xFF, 16); // 如果不满2位字符，则将其前面补一个"0"
+                continue;
+            }
             outFile += Integer.toString(sha1[i]&0xFF, 16);
         }
         return outFile;

--- a/src/Tree.java
+++ b/src/Tree.java
@@ -2,9 +2,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 
 public class Tree {
-    private String type;
-    private String name;
-    private String content = "";
+    private String type; // type is always tree
+    private String name; // sha-1 code for tree object
+    private String content = ""; // content of tree, such as "10644 blob sha1-code a.txt..."
 
     public Tree(String filename) throws Exception {
         File file = new File(filename);

--- a/src/unitTest.java
+++ b/src/unitTest.java
@@ -32,7 +32,7 @@ public class unitTest {
     }
 
     public static void main(String[] args){
-        String filename = "D:/课件/java/课程项目";
+        String filename = ".";
         testName(filename);
         testContent(filename);
 


### PR DESCRIPTION
请问我在本地测试的时候发现了某些文件或文件夹sha-1不满40位，发现是因为byte数组中的某一个不到16，那么就只有一个字符，我尝试在其前面补了一位0